### PR TITLE
1.3.0 Changes

### DIFF
--- a/files/css/element.css
+++ b/files/css/element.css
@@ -127,6 +127,10 @@
 
 // override Weebly default style
 .imageOverrides() {
+    .wsite-initial-image .element-box {
+        box-shadow: none !important;
+    }
+
     .wsite-image {
         padding: 0px !important;
     }

--- a/files/css/element.css
+++ b/files/css/element.css
@@ -61,11 +61,21 @@
                 overflow: hidden;
                 height: @width;
                 width: @width;
-                
+
                 img {
                     display: block;
                     width: auto;
                     height: auto;
+                }
+
+                div.wsite-image, a {
+                    height: @width;
+                    width: @width;
+                    display: block;
+                }
+
+                a {
+                    cursor: pointer;
                 }
             }
 
@@ -80,6 +90,17 @@
                     display: block;
                     width: auto;
                     height: auto;
+                }
+
+                div.wsite-image, a {
+                    border-radius: (@width / 2);
+                    height: @width - (@padding * 2);
+                    width: @width - (@padding * 2);
+                    display: block;
+                }
+
+                a {
+                    cursor: pointer;
                 }
             }
         }

--- a/files/js/element.js
+++ b/files/js/element.js
@@ -7,6 +7,7 @@
         initialize: function() {
             $(document).ready(function() {
                 this.fixStyles();
+                this.setUpImage();
             }.bind(this));
 
             this.fixStyles();
@@ -42,6 +43,76 @@
                 width: '',
                 height: ''
             });
+        },
+
+        setUpImage: function() {
+            var view = this;
+            var imageObserver = new MutationObserver(function(mutations) {
+                mutations.forEach(function(mutation) {
+                    view.updateImage();
+                });
+            });
+            imageObserver.observe(this.$('div.wsite-image img')[0], {
+                attributes: true
+            });
+            this.$('div.wsite-image a').click(function() {
+                $(this).find('img').click();
+            });
+            this.$('div.wsite-image img').click(function(e) {
+                e.stopPropagation();
+            });
+            this.updateImage();
+        },
+
+        updateImage: function() {
+            var $img = this.$('li.wsite-image img');
+            var $imgContainer = this.$('.team-card__image--' + this.settings.get('image_display'));
+            var isInitialImage = !!this.$('li.wsite-initial-image img').length;
+            // if there's no image to be found, stop executing.
+            if ($img.length == 0) {
+                return;
+            }
+            // grab sizes of the container and the image
+            var imageSize = {
+                height: $img.height(),
+                width: $img.width()
+            }
+            var containerSize = {
+                height: $imgContainer.height(),
+                width: $imgContainer.width()
+            }
+            // if any of these are zero, stop executing.
+            // if it's zero because the initial image hasn't loaded yet,
+            // then bind a recall to when it finishes.
+            if (!imageSize.height || !imageSize.width || !containerSize.height || !containerSize.width) {
+                if (isInitialImage) {
+                    $img.load(this.updateImage.bind(this));
+                }
+                return;
+            }
+            $img.unbind('load');
+            // determine whether he have an initial image or not
+            if (isInitialImage) {
+                // if we do, we need to move it to fit.
+                var dx = (containerSize.width - imageSize.width) / 2;
+                var dy = (containerSize.height - imageSize.height) / 2;
+                $img.css({
+                    'transform': 'translate(' + dx + 'px,' + dy + 'px)'
+                });                
+            } else {
+                // otherwise, if the image is smaller than the container, scale it up to fit.
+                var scale = 1;
+                if (imageSize.height < containerSize.height) {
+                    scale = containerSize.height / imageSize.height;
+                }
+                if (imageSize.width < containerSize.width) {
+                    scale = Math.max(scale, containerSize.width / imageSize.width);
+                }
+                $img.css({
+                    'transform-origin': 'top center',
+                    'transform': 'scale(' + scale + ', ' + scale + ')'
+                });
+            }
         }
     });
 

--- a/files/js/element.js
+++ b/files/js/element.js
@@ -45,8 +45,11 @@
             });
         },
 
+        // sets up the image for proper usage.
         setUpImage: function() {
             var view = this;
+
+            // begin listening for changes to the image source (i.e., someone uploading an image)
             var imageObserver = new MutationObserver(function(mutations) {
                 mutations.forEach(function(mutation) {
                     view.updateImage();
@@ -55,15 +58,20 @@
             imageObserver.observe(this.$('div.wsite-image img')[0], {
                 attributes: true
             });
+            // make the entire placeholder area clickable
             this.$('div.wsite-image a').click(function() {
                 $(this).find('img').click();
             });
+            // but prevent infinite loops
             this.$('div.wsite-image img').click(function(e) {
                 e.stopPropagation();
             });
             this.updateImage();
         },
 
+        // updates the image and transforms it depending on what needs to happen to it.
+        // if it's the default placeholder, we translate it so it's center in the image area
+        // if it's an uploaded image that's too small, we resize it so it'll fit.
         updateImage: function() {
             var $img = this.$('li.wsite-image img');
             var $imgContainer = this.$('.team-card__image--' + this.settings.get('image_display'));

--- a/manifest.json
+++ b/manifest.json
@@ -1,11 +1,11 @@
 {
   "manifest": "1",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "elements": [
     {
       "path": "files",
       "name": "Team Card",
-      "version": "1.2.1",
+      "version": "1.3.0",
       "settings": {
         "config": {
           "autopop": false


### PR DESCRIPTION
Changes: 

* Updates the UI for default images, so that the placeholder doesn't render as a half-circle, and the entire image view is clickable.
* Updates the logic for small images. If an image is too small in either direction (vertical or horizontal), then we'll scale the image accordingly.

I think screenshots better explain this.

## Old

![screen shot 2015-10-22 at 12 04 30 pm](https://cloud.githubusercontent.com/assets/5195030/10675586/f3e19bf6-78b5-11e5-8308-516e09718122.png)

![screen shot 2015-10-22 at 12 11 12 pm](https://cloud.githubusercontent.com/assets/5195030/10675602/05c6a67c-78b6-11e5-89ac-acd868a8eac0.png)

## New

![screen shot 2015-10-22 at 12 04 35 pm](https://cloud.githubusercontent.com/assets/5195030/10675591/f70cbe28-78b5-11e5-92fa-56e4375b5784.png)

![screen shot 2015-10-22 at 12 05 28 pm](https://cloud.githubusercontent.com/assets/5195030/10675605/089d4248-78b6-11e5-8164-5e94ead2d834.png)

@M-Porter  