### PR TITLE
1.3.2 Changes

### DIFF
--- a/files/css/element.css
+++ b/files/css/element.css
@@ -63,7 +63,6 @@
                 width: @width;
 
                 img {
-                    display: block;
                     width: auto;
                     height: auto;
                 }
@@ -87,7 +86,6 @@
                 margin: @padding @padding 0;
                 
                 img {
-                    display: block;
                     width: auto;
                     height: auto;
                 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,11 +1,11 @@
 {
   "manifest": "1",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "elements": [
     {
       "path": "files",
       "name": "Team Card",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "settings": {
         "config": {
           "autopop": false


### PR DESCRIPTION
There's a couple of display: block; that were causing small images to break.

@M-Porter @rchen1992 