### PR TITLE
overrides theme font color with @colorPrimary

### DIFF
--- a/files/css/editor_element.css
+++ b/files/css/editor_element.css
@@ -89,7 +89,7 @@
                 width: @width - (@padding * 2);
                 overflow: hidden;
                 margin: @padding @padding 0;
-                
+
                 img {
                     display: block;
                     width: auto;
@@ -150,6 +150,7 @@
 .overrides() {
     .paragraph {
         margin: 0 !important;
+        color: @colorPrimary;
         line-height: inherit;
     }
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,11 +1,11 @@
 {
   "manifest": "1",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "elements": [
     {
       "path": "files",
       "name": "Team Card",
-      "version": "1.3.4",
+      "version": "1.3.5",
       "settings": {
         "config": {
           "autopop": false


### PR DESCRIPTION
text in app was invisible when the site theme's default font color was white, this PR adds an override so that the app's font color is @colorPrimary

@puddi @rchen1992 
